### PR TITLE
Reposition the counter

### DIFF
--- a/res/style/numbertabs.less
+++ b/res/style/numbertabs.less
@@ -4,7 +4,7 @@
   float: left;
   position: relative;
   top: 2px;
-  left: 6px;
+  left: -4px;
 }
 
 .ohnnyj-generate-tabs(@n, @i: 1) when (@i =< @n) {


### PR DESCRIPTION
Hey ohnnyj,

First of all, thanks for this little extension, I like it, speeds up the things while working.

One thing that bugged me was that the counter blocked out those visual "notifications" that appear when a file is modified, or the closing "X" icon when hovering over the filename:

![problem](https://cloud.githubusercontent.com/assets/11914422/21524518/8cbb937e-cd0e-11e6-8465-3279bdf8c9d1.png)

I changed the "left" position of the counter in the less file, so everything can fit in, and now it looks like this:

![solution](https://cloud.githubusercontent.com/assets/11914422/21524531/ab272706-cd0e-11e6-87c0-a1ba2d9f0229.png)

What do you think?

Attila